### PR TITLE
feat: helm-s3: add chown for the .cache dir

### DIFF
--- a/init/agent-write-files.cfg
+++ b/init/agent-write-files.cfg
@@ -119,6 +119,7 @@ write_files:
       #!/bin/bash
 
       /home/linuxbrew/.linuxbrew/bin/helm plugin install https://github.com/hypnoglow/helm-s3.git
+      chown -R jenkins:jenkins /var/lib/jenkins/.cache/
     permissions: "000700"
     owner: root
     group: root

--- a/init/usagent-write-files.cfg
+++ b/init/usagent-write-files.cfg
@@ -119,6 +119,7 @@ write_files:
       #!/bin/bash
 
       /home/linuxbrew/.linuxbrew/bin/helm plugin install https://github.com/hypnoglow/helm-s3.git
+      chown -R jenkins:jenkins /var/lib/jenkins/.cache/
     permissions: "000700"
     owner: root
     group: root


### PR DESCRIPTION
Chmod .cache directory else Jenkins will not run "helm repo add" successfully