### PR TITLE
Modify Plugin install command to Include Pinned Versions

### DIFF
--- a/init/master-runcmd.cfg
+++ b/init/master-runcmd.cfg
@@ -29,7 +29,7 @@ runcmd:
   - mkdir /var/lib/jenkins/plugin-updates/archive
   - wget http://localhost:8080/jnlpJars/jenkins-cli.jar -P /var/cache/jenkins/war/WEB-INF/ -auth "admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)"
   - java -jar /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar -s "http://localhost:8080/" -auth "admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)" install-plugin $(cat /root/plugins.txt | tr "\n" " ")
-  - if [ -f "/root/custom_plugins.txt" ]; then java -jar /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar -s "http://localhost:8080/" -auth "admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)" install-plugin $(cat /root/custom_plugins.txt | tr "\n" " "); fi
+  - if [ -f "/root/custom_plugins.txt" ]; then java -jar /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar -s "http://localhost:8080/" -auth "admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)" install-plugin $(cat /root/custom_plugins.txt | sed -e 's/[: \t]*:[ \t]*/:/g' | tr "\n" " "); fi
   - service jenkins restart
   - sh /opt/wait_for_setup_done.sh
   - 'echo $''jenkins.model.Jenkins.instance.securityRealm.createAccount("admin", "${admin_password}")'' | java -jar /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar -s "http://localhost:8080/" -auth "admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)" groovy ='


### PR DESCRIPTION
The sed command will filter and format the custom_plugins.txt file correctly if the file contains plugins pinned to a specific version. ex: "pluginName: <versionNumber>". The Sed command will remove all types of spaces in the line to format correctly so that it can be given install command