### PR TITLE
Adding S3 download to Inline Policy to download PluginList from S3 bucket

### DIFF
--- a/init/master-runcmd.cfg
+++ b/init/master-runcmd.cfg
@@ -19,6 +19,7 @@ runcmd:
   - sed -i 's/#TimeoutStartSec=90/TimeoutStartSec=900/g' /usr/lib/systemd/system/jenkins.service
   - service jenkins start 
   - systemctl enable jenkins
+  - sudo aws s3 cp s3://testhq-admin-jenkins-store/pluginlist/plugin_list.txt /root/custom_plugins.txt
   - sh /opt/wait_for_setup_done.sh
   - sed -i -e "s@<slaveAgentPort>.*</slaveAgentPort>@<slaveAgentPort>49817</slaveAgentPort>@" /var/lib/jenkins/config.xml
   - sed -i -e "s@<numExecutors>.*</numExecutors>@<numExecutors>0</numExecutors>@" /var/lib/jenkins/config.xml

--- a/master.tf
+++ b/master.tf
@@ -52,6 +52,9 @@ resource "aws_iam_role_policy" "master_inline_policy" {
     {
       "Action": [
         "ec2:DescribeInstances",
+        "s3:GetObject",
+			  "s3:GetObjectAcl",
+			  "s3:PutObject",
         "autoscaling:DescribeAutoScalingGroups"
       ],
       "Effect": "Allow",

--- a/master.tf
+++ b/master.tf
@@ -53,8 +53,8 @@ resource "aws_iam_role_policy" "master_inline_policy" {
       "Action": [
         "ec2:DescribeInstances",
         "s3:GetObject",
-			  "s3:GetObjectAcl",
-			  "s3:PutObject",
+	"s3:GetObjectAcl",
+	"s3:PutObject",
         "autoscaling:DescribeAutoScalingGroups"
       ],
       "Effect": "Allow",


### PR DESCRIPTION
We separated the plugin list from the write_files in cloudinit to curb the issue of `file size limit` for user data. By uploading the plugin list file to and S3 bucket and then download it while setting up the cluster