### PR TITLE
27030: Let IAM role be able to read EC2 tags

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -52,6 +52,7 @@ resource "aws_iam_role_policy" "master_inline_policy" {
     {
       "Action": [
         "ec2:DescribeInstances",
+        "ec2:DescribeTags",
         "s3:GetObject",
         "s3:GetObjectAcl",
         "s3:PutObject",


### PR DESCRIPTION
This is to allow the Datadog agent to properly pick up instance metadata and tags